### PR TITLE
Fix isal-sys dependency for shared isal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ use-system-isal = ["isal-sys/use-system-isal"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-isal-sys = { path = "isal-sys", version = "0.5.2+496255c" }
+isal-sys = { path = "isal-sys", version = "0.5.2+496255c", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }


### PR DESCRIPTION
Fix the isal-sys dependency not to use default-features, in order to support using shared isal.  Otherwise, the default `static` feature always forces the static library.