### PR TITLE
Do not include test-data/ in published isal-rs crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude = [
   ".gitmodules",
   ".github/",
   "benches/",
+  "test-data/",
 ]
 
 [lib]


### PR DESCRIPTION
This PR excludes `test-data/` for published `isal-rs` crates for several reasons:

- In practice, this test corpus is only used for the benchmarks, which are already not distributed in the crate – the tests are unaffected by omitting it.
- Some of the contents are subject to complicated or unclear license terms, which is an issue for those (such as distribution packagers) who would need to redistribute the source archive (`.crate` file).
- Omitting the test data makes the released crates vastly smaller (13K instead of 986K).