### PR TITLE
Fix target triple for riscv64

### DIFF
--- a/isal-sys/build.rs
+++ b/isal-sys/build.rs
@@ -9,7 +9,13 @@ fn main() {
 
     let is_static = cfg!(feature = "static");
     let is_shared = cfg!(feature = "shared");
-    let target = std::env::var("TARGET").unwrap();
+    let rust_target = std::env::var("TARGET").unwrap();
+    let target = if rust_target.starts_with("riscv64") {
+        let (_cpu, rest) = rust_target.split_once('-').unwrap();
+        format!("riscv64-{rest}")
+    } else {
+        rust_target
+    };
     let out_dir = PathBuf::from(&std::env::var("OUT_DIR").unwrap());
 
     // Copy isa-l source into out; not allow to modify things outside of out dir


### PR DESCRIPTION
Rust uses `riscv64gc-*-*-*` which includes the ISA exts, while autoconf tooling doesn't expect them to be there.

Strip the ISA exts from rust riscv64 triples to fix it.

Fixes https://archriscv.felixc.at/.status/log.htm?url=logs/python-cramjam/python-cramjam-2.9.1-1.log